### PR TITLE
Fix #1 Loading a savegame throws "__StrictEngagements__/control.lua:3…

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -32,16 +32,6 @@ local function globalVarInit()
 	}
 end
 
-
-local function playerInit(reset)
- if reset or not global.playerData then global.playerData = {} end
-	for _, player in pairs(game.players) do
-		newPlayerInit(player, reset)
-		doDebug("playerInit: New Player Added")
-	end
-end
-
-
 local function newPlayerInit(player, reset)	-- initialize or update per player globals of the mod
 	if global.playerData == nil then global.playerData = {} end
 	if reset == true or global.playerData[player.index] == nil then
@@ -52,6 +42,13 @@ local function newPlayerInit(player, reset)	-- initialize or update per player g
 	end
 end
 
+local function playerInit(reset)
+ if reset or not global.playerData then global.playerData = {} end
+	for _, player in pairs(game.players) do
+		newPlayerInit(player, reset)
+		doDebug("playerInit: New Player Added")
+	end
+end
 
 local function OnGameInit() --Called when mod is first added to a new game
     doDebug("OnGameInit: Initial Setup Started")

--- a/info.json
+++ b/info.json
@@ -1,11 +1,11 @@
 {
   "name": "StrictEngagements",
-  "version": "0.0.1",
-  "factorio_version" : "0.13",
+  "version": "0.0.2",
+  "factorio_version" : "0.14",
   "title": "Strict Engagements",
   "author": "Nexela",
   "contact": "",
   "www": "",
   "description": "No longer allowed to build items if you are too close to biters.",
-  "dependencies": ["base >= 0.13.10"]
+  "dependencies": ["base >= 0.14"]
 }


### PR DESCRIPTION
…9: attempt to call global 'newPlayerInit' (a nil value)"